### PR TITLE
GetOne generic fetching

### DIFF
--- a/web/components/getOne.ts
+++ b/web/components/getOne.ts
@@ -1,0 +1,101 @@
+import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
+import * as grpc from "@grpc/grpc-js";
+import * as jspb from 'google-protobuf'
+import { Error, StatusCode } from "grpc-web";
+
+interface Instance extends jspb.Message {
+  getId: () => number;
+  toObject: () => any;
+}
+
+interface getByIDRequest<T extends Instance> extends jspb.Message {
+  setId: (id: number) => getByIDRequest<T>;
+}
+
+interface getByIDResponse<T extends Instance> extends jspb.Message {
+  getResult: () => T;
+}
+
+interface getByIDClient<T extends Instance> {
+  getOneByID(request: getByIDRequest<T>, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: getByIDResponse<T>) => void): grpc.ClientUnaryCall;
+}
+
+interface pageProp<T extends Instance> {
+  id: number;
+  result?: T;
+  errorCode?: number;
+}
+
+type getServerSideFunc<T extends Instance> = (context: GetServerSidePropsContext) => Promise<GetServerSidePropsResult<pageProp<T>>>;
+
+const httpStatusCode = (grpcCode: number): number => {
+  switch (grpcCode) {
+    case StatusCode.OK:
+      return 200
+    case StatusCode.NOT_FOUND:
+      return 404
+    case StatusCode.DEADLINE_EXCEEDED:
+      return 503
+    default:
+      return 500
+  }
+};
+
+export const getOneByID = async<T extends Instance>(
+  context: GetServerSidePropsContext,
+  request: getByIDRequest<T>,
+  client: getByIDClient<T>,
+  authorizationToken?: string,
+): Promise<GetServerSidePropsResult<pageProp<T>>> => {
+  let id: number;
+
+  if (Array.isArray(context.params.id)) {
+    id = parseInt(context.params.id[0], 10);
+  } else {
+    id = parseInt(context.params.id, 10);
+  }
+
+  const props: pageProp<T> = {
+    id,
+    result: null,
+    errorCode: null,
+  };
+
+  const metadata = new grpc.Metadata();
+
+  if (authorizationToken) {
+    metadata.set('Authorization', 'Bearer ' + authorizationToken);
+  }
+
+  request.setId(id);
+  const p = new Promise((resolve, reject) =>
+    client.getOneByID(request, metadata, (err: Error, response: getByIDResponse<T>) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(response);
+    })
+  );
+
+  // await (p);
+  await p
+    .then(
+      (response: getByIDResponse<T>) => {
+        props.result = response.getResult().toObject();
+      },
+      (e: Error) => {
+        props.errorCode = e.code;
+      }
+    )
+    .catch(() => {
+      props.errorCode = StatusCode.UNKNOWN;
+    });
+
+  if (props.errorCode) {
+    context.res.statusCode = httpStatusCode(props.errorCode)
+  }
+
+  return {
+    props,
+  };
+};

--- a/web/components/getOne.ts
+++ b/web/components/getOne.ts
@@ -23,7 +23,7 @@ interface getByIDClient<T extends Instance> {
 
 interface pageProp<T extends Instance> {
   id: number;
-  result?: T;
+  result?: T; // TODO: this is not the most semantically correct since this is actually the AsObject representation of the protobuf message
   errorCode?: number;
 }
 

--- a/web/components/getOne.ts
+++ b/web/components/getOne.ts
@@ -65,7 +65,7 @@ export const GetOneByIDServerSide = <O extends pbMessageAsObject, PB extends pbM
       id = parseInt(context.params.id, 10);
     }
 
-    const props: pageProp<T> = {
+    const props: PageProp<T> = {
       id,
       result: null,
       error: null,

--- a/web/components/getOne.ts
+++ b/web/components/getOne.ts
@@ -2,6 +2,7 @@ import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 import * as grpc from "@grpc/grpc-js";
 import * as jspb from 'google-protobuf'
 import { Error, StatusCode } from "grpc-web";
+import { ParsedUrlQuery } from 'querystring'
 
 interface Instance extends jspb.Message {
   getId: () => number;
@@ -26,6 +27,10 @@ interface pageProp<T extends Instance> {
   errorCode?: number;
 }
 
+interface QueryWithIDParam extends ParsedUrlQuery {
+  id: string | string[]
+}
+
 export type GetServerSideFunc<T extends Instance> = (context: GetServerSidePropsContext) => Promise<GetServerSidePropsResult<pageProp<T>>>;
 
 const httpStatusCode = (grpcCode: number): number => {
@@ -46,7 +51,7 @@ export const GetOneByID = <T extends Instance>(
   client: getByIDClient<T>,
   authorizationToken?: string,
 ): GetServerSideFunc<T> => {
-  return async (context: GetServerSidePropsContext): Promise<GetServerSidePropsResult<pageProp<T>>> => {
+  return async (context: GetServerSidePropsContext<QueryWithIDParam>): Promise<GetServerSidePropsResult<pageProp<T>>> => {
     let id: number;
 
     if (Array.isArray(context.params.id)) {

--- a/web/components/getOne.ts
+++ b/web/components/getOne.ts
@@ -65,7 +65,7 @@ export const GetOneByIDServerSide = <O extends pbMessageAsObject, PB extends pbM
       id = parseInt(context.params.id, 10);
     }
 
-    const props: PageProp<T> = {
+    const props: PageProp<O> = {
       id,
       result: null,
       error: null,

--- a/web/components/getOne.ts
+++ b/web/components/getOne.ts
@@ -82,7 +82,6 @@ export const GetOneByID = <T extends Instance>(
       })
     );
 
-    // await (p);
     await p
       .then(
         (response: getByIDResponse<T>) => {

--- a/web/components/getOne.ts
+++ b/web/components/getOne.ts
@@ -7,6 +7,7 @@ import { ParsedUrlQuery } from 'querystring'
 interface pbMessageAsObject {
   id: number;
 }
+
 interface pbMessage<O extends pbMessageAsObject> extends jspb.Message {
   getId: () => number;
   toObject: () => O;

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "react-helmet": "^6.1.0"
   },
   "devDependencies": {
+    "@types/google-protobuf": "^3.7.4",
     "@types/node": "^14.14.10",
     "@types/react": "^17.0.0",
     "@types/react-helmet": "^6.1.0",

--- a/web/pages/phone/[id].tsx
+++ b/web/pages/phone/[id].tsx
@@ -7,21 +7,15 @@ import { GetOneByIDRequest } from "../../protobuf/phone/phone_service_pb";
 import { Phone } from "../../protobuf/phone/phone_pb";
 import PhoneServiceClient from "../../clients/nodejs/phone_service_client";
 import PhoneComponent from "../../components/phone";
-import { GetOneByID, GetServerSideFunc } from "../../components/getOne";
+import { GetOneByIDServerSide, GetServerSideFunc, PageProp } from "../../components/getOne";
 
-export const getServerSideProps: GetServerSideFunc<Phone> = GetOneByID(
+export const getServerSideProps: GetServerSideFunc<Phone.AsObject> = GetOneByIDServerSide<Phone.AsObject, Phone>(
   new GetOneByIDRequest(),
   PhoneServiceClient,
   "legit",
 );
 
-interface PhonePageProp {
-  id: number;
-  result?: Phone.AsObject;
-  error?: Error;
-}
-
-const PhonePage = (props: PhonePageProp): JSX.Element => {
+const PhonePage = (props: PageProp<Phone.AsObject>): JSX.Element => {
   if (props.result) {
     return (
       <Container defKey="1">

--- a/web/pages/phone/[id].tsx
+++ b/web/pages/phone/[id].tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StatusCode } from "grpc-web";
+import { Error, StatusCode } from "grpc-web";
 import Container from "../../components/container";
 import SEO from "../../components/seo";
 import Custom404 from "../404";
@@ -18,7 +18,7 @@ export const getServerSideProps: GetServerSideFunc<Phone> = GetOneByID(
 interface PhonePageProp {
   id: number;
   result?: Phone.AsObject;
-  errorCode?: number;
+  error?: Error;
 }
 
 const PhonePage = (props: PhonePageProp): JSX.Element => {
@@ -31,7 +31,7 @@ const PhonePage = (props: PhonePageProp): JSX.Element => {
     );
   }
 
-  if (props.errorCode === StatusCode.NOT_FOUND) {
+  if (props.error.code === StatusCode.NOT_FOUND) {
     return (
       <Custom404
         defKey="1"
@@ -41,7 +41,7 @@ const PhonePage = (props: PhonePageProp): JSX.Element => {
     );
   }
 
-  if (props.errorCode === StatusCode.DEADLINE_EXCEEDED) {
+  if (props.error.code === StatusCode.DEADLINE_EXCEEDED) {
     return (
       <Container defKey="1">
         <h1>503</h1>

--- a/web/pages/phone/[id].tsx
+++ b/web/pages/phone/[id].tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Error, StatusCode } from "grpc-web";
+import { StatusCode } from "grpc-web";
 import Container from "../../components/container";
 import SEO from "../../components/seo";
 import Custom404 from "../404";
@@ -35,17 +35,9 @@ const PhonePage = (props: PageProp<Phone.AsObject>): JSX.Element => {
     );
   }
 
-  if (props.error.code === StatusCode.DEADLINE_EXCEEDED) {
-    return (
-      <Container defKey="1">
-        <h1>503</h1>
-      </Container>
-    );
-  }
-
   return (
     <Container defKey="1">
-      <h1>500</h1>
+      <h1>{props.httpStatusCode}</h1>
     </Container>
   );
 };

--- a/web/pages/phone/[id].tsx
+++ b/web/pages/phone/[id].tsx
@@ -43,13 +43,6 @@ const PhonePage = (props: PhonePageProp): JSX.Element => {
 
   if (props.errorCode === StatusCode.DEADLINE_EXCEEDED) {
     return (
-      // <NotFoundPage
-      //   code={503}
-      //   title="Timeout"
-      //   message={
-      //     `Waited too long while fetching phone with id=${id}`
-      //   }
-      // />
       <Container defKey="1">
         <h1>503</h1>
       </Container>
@@ -57,11 +50,6 @@ const PhonePage = (props: PhonePageProp): JSX.Element => {
   }
 
   return (
-    // <NotFoundPage
-    //   code={500}
-    //   title="Internal server error"
-    //   message={`Error fetching phone with id=${id}`}
-    // />
     <Container defKey="1">
       <h1>500</h1>
     </Container>

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -251,6 +251,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@types/google-protobuf@^3.7.4":
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.7.4.tgz#1621c50ceaf5aefa699851da8e0ea606a2943a39"
+  integrity sha512-6PjMFKl13cgB4kRdYtvyjKl8VVa0PXS2IdVxHhQ8GEKbxBkyJtSbaIeK1eZGjDKN7dvUh4vkOvU9FMwYNv4GQQ==
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"


### PR DESCRIPTION
The pattern of fetching one object by ID is pretty generic, so let's use generics to genericize the client-side fetching. Related: https://github.com/rickypai/web-template/pull/11