### PR TITLE
Add meta for JavaScript Analysis and Autofix

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -16,3 +16,8 @@ enabled = true
 [[analyzers]]
 name = "javascript"
 enabled = true
+
+    [analyzers.meta]
+    environment = ["nodejs"]
+    style_guide = "airbnb"
+    dialect = "typescript" 


### PR DESCRIPTION
I have added the meta field for the JavaScript Analyzer which will help you with a better experience using DeepSource.